### PR TITLE
fix: get git commit hash in another way

### DIFF
--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -115,7 +115,8 @@ done
 
 set -euo pipefail
 
-version=$(git rev-parse HEAD)
+version=$(git --git-dir .git log -n 1 --pretty=format:"%H")
+
 echo "clcbioformatter_version: '${version}'" >> "${OUTPUTDIR}/metadata.yml"
 
 if [ ${result} == 0 ]


### PR DESCRIPTION
A patch in `git` (https://github.blog/2022-04-12-git-security-vulnerability-announced/) meant that getting the latest commit did not work as expected any more. Now implemented the way to get the latest commit which is used in juno-library (https://github.com/RIVM-bioinformatics/juno-library/blob/00c8f14a7e83ddff5e1302eb7efe91568a63c65a/juno_library/helper_functions.py#L120)