### PR TITLE
Fix smk version

### DIFF
--- a/envs/master_env.yaml
+++ b/envs/master_env.yaml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - snakemake-minimal
+  - snakemake-minimal=7.24
+  - python<3.12

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ URL = 'https://github.com/AleSR13/clcbioformatter'
 EMAIL = 'ale.hdz.segura@gmail.com'
 AUTHOR = 'Alejandra Hernández Segura'
 REQUIRES_PYTHON = '>=3.9'
-VERSION = '0.1.6'
+VERSION = '0.1.7'
 
 
 REQUIRED = [


### PR DESCRIPTION
snakemake version 7.29 and 7.30 have a new singularity version parsing which requires packaging (and will subsequently fail on our system because of a non-PEP440-compliant version format, ). Fixing the snakemake version to 7.24 now.

Starting from snakemake version 7.30.2, a fix is implemented to solve the parsing issue, allowing this repo to use the latest version if needed